### PR TITLE
HTML doc cleanups and fix incorrect license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-# CockroachdB ChangeFeed Consumer
+# RoachFeed
 
-Consumes a CockroachDB Core ChangeFeed. Doesn't use Postgrex (except for testing). Doesn't open a pool. It open a single (per instance) tcp connection which is optimized for dealing with feed data.
+[![hex.pm](https://img.shields.io/hexpm/v/roachfeed.svg)](https://hex.pm/packages/roachfeed)
+[![hex.pm](https://img.shields.io/hexpm/dt/roachfeed.svg)](https://hex.pm/packages/roachfeed)
+[![hex.pm](https://img.shields.io/hexpm/l/roachfeed.svg)](https://hex.pm/packages/roachfeed)
+[![github.com](https://img.shields.io/github/last-commit/karlseguin/roachfeed.svg)](https://github.com/karlseguin/roachfeed)
 
-Usage:
+Consumes a CockroachDB Core ChangeFeed. Doesn't use Postgrex (except for
+testing). Doesn't open a pool. It open a single (per instance) TCP connection
+which is optimized for dealing with feed data.
 
-In your mix.exs file, add the project dependency:
+## Usage
+
+In your `mix.exs` file, add the project dependency:
 
 ```
 {:roachfeed, "~> 0.0.7"}
@@ -14,48 +21,53 @@ Next create a module:
 
 ```elixir
 defmodule MyModule do
-	use RoachFeed
+  use RoachFeed
 
-	defp setup(_opts) do
-		state = nil
-		connection_config = Application.fetch_env!(:app, :config)
-		{state, connection_config}
-	end
+  defp setup(_opts) do
+    state = nil
+    connection_config = Application.fetch_env!(:app, :config)
+    {state, connection_config}
+  end
 
-	# Called once the connection is estasblished.
-	# `for` must be specified (it can be a list of table, or a single table)
-	# `with` is an optional keyword list that matches the options that
-	#        'experimental changefeed for ...' supports
-	#        (Note: it's OK to pass `nil` to the `cursor` key)
-	defp query(state) do
-		changefeed_config = [
-			for: ["table_1", "table_2"],
-			with: [
-				resolved: "10s",
-				cursor: elem(state, 2)[:resolved]
-			]
-		]
-		{state, changefeed_config}
-	end
+  # Called once the connection is estasblished.
+  # `for` must be specified (it can be a list of table, or a single table)
+  # `with` is an optional keyword list that matches the options that
+  #        'experimental changefeed for ...' supports
+  #        (Note: it's OK to pass `nil` to the `cursor` key)
+  defp query(state) do
+    changefeed_config = [
+      for: ["table_1", "table_2"],
+      with: [
+        resolved: "10s",
+        cursor: elem(state, 2)[:resolved]
+      ]
+    ]
+    {state, changefeed_config}
+  end
 
-	# `msg` is not parsed. You probably want to Jason.decode!/1 it.
-	defp handle_resolved(msg, state) do
-		IO.inspect(msg)
-		state
-	end
+  # `msg` is not parsed. You probably want to Jason.decode!/1 it.
+  defp handle_resolved(msg, state) do
+    IO.inspect(msg)
+    state
+  end
 
-	# `key` and `data` are not parsed. You may want to Jason.decode/1 them.
-	# If `envelope: "key_only` is passed to the `with:` keyword list of
-	# `query/1`, then `data` will be nil.
-	defp handle_change(table, key, data, state) do
-		IO.inspect({table, key, data})
-		state
-	end
+  # `key` and `data` are not parsed. You may want to Jason.decode/1 them.
+  # If `envelope: "key_only` is passed to the `with:` keyword list of
+  # `query/1`, then `data` will be nil.
+  defp handle_change(table, key, data, state) do
+    IO.inspect({table, key, data})
+    state
+  end
 end
 ```
 
-Start `MyModule` (as a child of a supervisor most likely), passing it the typically connection string value:
+Start `MyModule` (as a child of a supervisor most likely), passing it the
+typically connection string value:
 
 ```elixir
 {MyModule, [any_opts_you_want_passed_to_setup/1]}
 ```
+
+## License
+
+[ISC](LICENSE) Copyright (c) 2020, Karl Seguin

--- a/mix.exs
+++ b/mix.exs
@@ -1,40 +1,56 @@
 defmodule RoachFeed.MixProject do
-	use Mix.Project
+  use Mix.Project
 
-	@version "0.0.7"
+  @source_url "https://github.com/karlseguin/roachfeed"
+  @version "0.0.7"
 
-	def project do
-		[
-			app: :roachfeed,
-			deps: deps(),
-			elixir: "~> 1.10",
-			version: @version,
-			elixirc_paths: paths(Mix.env),
-			description: "CockroachDB ChangeFeed Consumer",
-			package: [
-				licenses: ["MIT"],
-				links: %{
-					"git" => "https://github.com/karlseguin/roachfeed"
-				},
-				maintainers: ["Karl Seguin"],
-			],
-		]
-	end
+  def project do
+    [
+      app: :roachfeed,
+      name: "RoachFeed",
+      deps: deps(),
+      elixir: "~> 1.10",
+      version: @version,
+      elixirc_paths: paths(Mix.env()),
+      description: "CockroachDB ChangeFeed Consumer",
+      package: package(),
+      docs: docs()
+    ]
+  end
 
-	defp paths(:test), do: paths(:prod) ++ ["test/support"]
-	defp paths(_), do: ["lib"]
+  defp paths(:test), do: paths(:prod) ++ ["test/support"]
+  defp paths(_), do: ["lib"]
 
-	def application do
-		[
-			extra_applications: [:logger]
-		]
-	end
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
 
-	defp deps do
-		[
-			{:jason, "~>1.2.2", only: :test},
-			{:postgrex, "~>0.15.6", only: :test},
-			{:ex_doc, "~> 0.22.6", only: :dev, runtime: false},
-		]
-	end
+  defp deps do
+    [
+      {:jason, "~>1.2.2", only: :test},
+      {:postgrex, "~>0.15.6", only: :test},
+      {:ex_doc, "~> 0.22.6", only: :dev, runtime: false}
+    ]
+  end
+
+  defp package do
+    [
+      maintainers: ["Karl Seguin"],
+      licenses: ["ISC"],
+      links: %{"GitHub" => @source_url}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      source_url: @source_url,
+      extras: [
+        "README.md",
+        "LICENSE"
+      ]
+    ]
+  end
 end


### PR DESCRIPTION
This PR refactors the HTML doc generation which includes:

- Use common source URL.
- Add link back to Github URL for function header.
- Fix incorrect license type.
- Badges and more badges.